### PR TITLE
Allow for radio and checkbox menu items

### DIFF
--- a/d2l-dropdown-menu.html
+++ b/d2l-dropdown-menu.html
@@ -77,10 +77,10 @@
 			},
 
 			_onSelect: function(e) {
-				if (e.target.tagName !== 'D2L-MENU-ITEM') {
-					return;
+				// Applies to d2l-menu-item, d2l-menu-item-radio, and d2l-menu-item-checkbox
+				if (e.target.tagName.indexOf('D2L-MENU-ITEM') === 0) {
+					this.close();
 				}
-				this.close();
 			}
 
 		});


### PR DESCRIPTION
Menu wasn't auto-closing after clicking a radio or checkbox item as I failed to update this when I added them - whoops. See also https://github.com/Brightspace/d2l-menu-ui/pull/20