### PR TITLE
US80149 - Only apply focus in content if keyboard/enter.

### DIFF
--- a/d2l-dropdown-content-behavior.html
+++ b/d2l-dropdown-content-behavior.html
@@ -244,15 +244,16 @@
 			this.opened = false;
 		},
 
-		open: function() {
+		open: function(applyFocus) {
+			this.__applyFocus = applyFocus !== undefined ? applyFocus : true;
 			this.opened = true;
 		},
 
-		toggleOpen: function() {
+		toggleOpen: function(applyFocus) {
 			if (this.opened) {
 				this.close();
 			} else {
-				this.open();
+				this.open(applyFocus);
 			}
 		},
 
@@ -377,7 +378,7 @@
 
 				this.__position();
 
-				if (!this.noAutoFocus) {
+				if (!this.noAutoFocus && this.__applyFocus) {
 					var focusable = D2L.Dom.Focus.getFirstFocusableDescendant(this);
 					if (focusable) {
 						focusable.focus();

--- a/d2l-dropdown-menu.html
+++ b/d2l-dropdown-menu.html
@@ -70,9 +70,11 @@
 				Polymer.dom(menu).setAttribute('no-animate-height', '');
 				menu.resize();
 
-				setTimeout(function() {
-					menu.focus();
-				}, 0);
+				if (this.__applyFocus) {
+					setTimeout(function() {
+						menu.focus();
+					}, 0);
+				}
 
 			},
 

--- a/d2l-dropdown-opener-behavior.html
+++ b/d2l-dropdown-opener-behavior.html
@@ -42,11 +42,14 @@
 		},
 
 		attached: function() {
-			var opener = this.getOpenerElement();
-			if (!opener) {
-				return;
-			}
-			this.listen(opener, 'click', '__onClick');
+			Polymer.RenderStatus.afterNextRender(this, function() {
+				var opener = this.getOpenerElement();
+				if (!opener) {
+					return;
+				}
+				this.listen(opener, 'keypress', '__onKeyPress');
+				this.listen(opener, 'mouseup', '__onMouseUp');
+			}.bind(this));
 		},
 
 		detached: function() {
@@ -54,7 +57,8 @@
 			if (!opener) {
 				return;
 			}
-			this.unlisten(opener, 'click', '__onClick');
+			this.unlisten(opener, 'keypress', '__onKeyPress');
+			this.unlisten(opener, 'mouseup', '__onMouseUp');
 		},
 
 		getOpener: function() {
@@ -65,19 +69,29 @@
 			return this;
 		},
 
-		toggleOpen: function() {
+		toggleOpen: function(applyFocus) {
 			var content = this.queryEffectiveChildren('[d2l-dropdown-content]');
 			if (!content) {
 				return;
 			}
-			content.toggleOpen();
+			content.toggleOpen(applyFocus);
 		},
 
-		__onClick: function() {
+		__onKeyPress: function(e) {
+			if (e.keyCode !== 13) {
+				return;
+			}
 			if (this.noAutoOpen) {
 				return;
 			}
-			this.toggleOpen();
+			this.toggleOpen(true);
+		},
+
+		__onMouseUp: function(e) {
+			if (this.noAutoOpen) {
+				return;
+			}
+			this.toggleOpen(false);
 		}
 
 	};

--- a/d2l-dropdown-opener-behavior.html
+++ b/d2l-dropdown-opener-behavior.html
@@ -87,7 +87,7 @@
 			this.toggleOpen(true);
 		},
 
-		__onMouseUp: function(e) {
+		__onMouseUp: function() {
 			if (this.noAutoOpen) {
 				return;
 			}


### PR DESCRIPTION
Behavior change: only focus on content of dropdown is the user activated the opener via keyboard.  If the user clicks with mouse, do not auto focus on dropdown content, leave focus on opener.