### PR TITLE
Dbatiste/defer render content

### DIFF
--- a/d2l-dropdown-content-behavior.html
+++ b/d2l-dropdown-content-behavior.html
@@ -205,10 +205,7 @@
 				type: Boolean,
 				reflectToAttribute: true
 			},
-			renderContent: {
-				type: Boolean,
-				value: false
-			}
+			renderContent: Boolean
 		},
 
 		__content: null,

--- a/d2l-dropdown-content-behavior.html
+++ b/d2l-dropdown-content-behavior.html
@@ -204,6 +204,10 @@
 			openedAbove: {
 				type: Boolean,
 				reflectToAttribute: true
+			},
+			renderContent: {
+				type: Boolean,
+				value: false
 			}
 		},
 
@@ -373,7 +377,7 @@
 
 			this.__isRTL = (getComputedStyle(this).direction === 'rtl');
 
-			if (newValue) {
+			var doOpen = function() {
 
 				var content = this.__getContentContainer();
 
@@ -394,6 +398,18 @@
 				}
 
 				this.fire('d2l-dropdown-open');
+
+			}.bind(this);
+
+			if (newValue) {
+
+				if (!this.renderContent) {
+					this.renderContent = true;
+				}
+
+				Polymer.RenderStatus.afterNextRender(this, function() {
+					doOpen();
+				}.bind(this));
 
 			} else {
 

--- a/d2l-dropdown-content.html
+++ b/d2l-dropdown-content.html
@@ -9,7 +9,9 @@
 			<div class="d2l-dropdown-content-width">
 				<div class="d2l-dropdown-content-top"></div>
 				<div class="d2l-dropdown-content-container">
-					<content></content>
+					<template is="dom-if" if="[[renderContent]]">
+						<content></content>
+					</template>
 				</div>
 				<div class="d2l-dropdown-content-bottom"></div>
 			</div>

--- a/d2l-dropdown-menu.html
+++ b/d2l-dropdown-menu.html
@@ -10,7 +10,9 @@
 			<div class="d2l-dropdown-content-width">
 				<div class="d2l-dropdown-content-top"></div>
 				<div class="d2l-dropdown-content-container">
-					<content></content>
+					<template is="dom-if" if="[[renderContent]]">
+						<content></content>
+					</template>
 				</div>
 				<div class="d2l-dropdown-content-bottom"></div>
 			</div>


### PR DESCRIPTION
@dlockhart : this change effectively defers rendering of the dropdown content in the DOM tree until the dropdown is opened for the first time.  Deferring appears to reduce `d2l.page.display` on Home Page by about 9.8% in Chrome, and 14.2% in IE.

A side effect (that consumers would not expect) is that if they attempt to access dropdown content before first-open, they will have trouble because the template nodes haven't been stamped into the DOM.  The grafted nav dropdowns have this problem because they try to access the placeholder before opening.  To handle this case, the consumer can force rendering by applying the `render-content` attribute to `d2l-dropdown-content`.  I am considering adding an attribute explicitly to control that: `no-defer-render`.  Also considering switching the behavior so that they would be opting into deferring rather than opting out - that might be more what the consumer would expect.

Thoughts on approach?  

An alternative but similar approach would be that consumers do this themselves, but I think it's behavior the dropdown should be able to provide.  In addition, since type extensions are eventually going away, it would be preferred to not require updating more components than necessary. (i.e. migration is `<template is="dom-if">...</template>` -> `<dom-if><template>...</template></dom-if>`)

@ryantmer : I did some testing in the my-courses widget and it seems to be unaffected by this change from what I can tell.  I think I recall some custom stuff being done there, so thought I'd cc you here in case you are aware of something that may break.  There may also be some opportunity to defer work done by some my-courses components in a similar way, or perhaps defer rendering altogether.  If this isn't something being done, there could be some significant perf gains.
