### PR TITLE
uses overflow-y auto for d2l-dropdown-content

### DIFF
--- a/d2l-dropdown-content-behavior.html
+++ b/d2l-dropdown-content-behavior.html
@@ -226,7 +226,7 @@
 			this.__onAutoCloseClick = this.__onAutoCloseClick.bind(this);
 
 			this.__mutationObserver = new MutationObserver(function() {
-				this.__toggleOverflowY()
+				this.__toggleOverflowY();
 			}.bind(this));
 		},
 
@@ -556,12 +556,12 @@
 		},
 
 		__toggleOverflowY: function() {
-			if (!this.__content || !this.__content.style || !this.__content.style.maxHeight){
+			if (!this.__content || !this.__content.style || !this.__content.style.maxHeight) {
 				return;
 			}
 
 			var maxHeight = parseInt(this.__content.style.maxHeight.replace(/[^0-9\.]/g, ''), 10);
-			if (!maxHeight){
+			if (!maxHeight) {
 				return;
 			}
 

--- a/d2l-dropdown-content-behavior.html
+++ b/d2l-dropdown-content-behavior.html
@@ -158,6 +158,8 @@
 (function() {
 	'use strict';
 
+	var mutationObserver;
+
 	/** @polymerBehavior */
 	var DropdownContentBehavior = {
 
@@ -222,6 +224,12 @@
 			this.__onResize = this.__onResize.bind(this);
 			this.__onAutoCloseFocus = this.__onAutoCloseFocus.bind(this);
 			this.__onAutoCloseClick = this.__onAutoCloseClick.bind(this);
+
+			mutationObserver = new MutationObserver(function(mutations) {
+				mutations.forEach(function(mutation) {
+					this.__toggleOverflowY();
+				}.bind(this));
+			}.bind(this));
 		},
 
 		attached: function() {
@@ -242,6 +250,8 @@
 				this.listen(this, 'd2l-dropdown-position', '__toggleScrollStyles');
 				this.listen(this.__content, 'scroll', '__toggleScrollStyles');
 
+				var config = { childList: true }
+				mutationObserver.observe(this.__getContentContainer(), config);
 			}.bind(this));
 		},
 
@@ -253,6 +263,7 @@
 			this.unlisten(this, 'd2l-dropdown-close', '__onClose');
 			this.unlisten(this, 'd2l-dropdown-position', '__toggleScrollStyles');
 			this.unlisten(this.__content, 'scroll', '__toggleScrollStyles');
+			mutationObserver.disconnect();
 		},
 
 		close: function() {
@@ -518,7 +529,7 @@
 
 				if (!this.noAutoFit && maxHeight && maxHeight > 0) {
 					content.style.maxHeight = maxHeight + 'px';
-					content.style.overflowY = 'auto';
+					this.__toggleOverflowY();
 				}
 
 				this.fire('d2l-dropdown-position');
@@ -540,6 +551,17 @@
 
 			adjustPosition();
 
+		},
+
+		__toggleOverflowY: function() {
+			var content = this.__getContentContainer();
+			var maxHeight = parseInt(content.style.maxHeight.replace(/[^0-9\.]/g, ''), 10);
+			if (content.scrollHeight > maxHeight) {
+				content.style.overflowY = 'auto';
+			} else {
+				/* needed for IE */
+				content.style.overflowY = '';
+			}
 		},
 
 		__toggleScrollStyles: function() {

--- a/d2l-dropdown-content-behavior.html
+++ b/d2l-dropdown-content-behavior.html
@@ -518,12 +518,7 @@
 
 				if (!this.noAutoFit && maxHeight && maxHeight > 0) {
 					content.style.maxHeight = maxHeight + 'px';
-					if (content.scrollHeight > maxHeight) {
-						content.style.overflowY = 'auto';
-					} else {
-						/* needed for IE */
-						content.style.overflowY = '';
-					}
+					content.style.overflowY = 'auto';
 				}
 
 				this.fire('d2l-dropdown-position');

--- a/d2l-dropdown-content-behavior.html
+++ b/d2l-dropdown-content-behavior.html
@@ -225,10 +225,8 @@
 			this.__onAutoCloseFocus = this.__onAutoCloseFocus.bind(this);
 			this.__onAutoCloseClick = this.__onAutoCloseClick.bind(this);
 
-			this.__mutationObserver = new MutationObserver(function(mutations) {
-				mutations.forEach(function(mutation) {
-					this.__toggleOverflowY();
-				}.bind(this));
+			this.__mutationObserver = new MutationObserver(function() {
+				this.__toggleOverflowY()
 			}.bind(this));
 		},
 
@@ -250,8 +248,10 @@
 				this.listen(this, 'd2l-dropdown-position', '__toggleScrollStyles');
 				this.listen(this.__content, 'scroll', '__toggleScrollStyles');
 
-				var config = { subtree: true, childList: true }
-				this.__mutationObserver.observe(this.__getContentContainer(), config);
+				if (!this.noAutoFit) {
+					var config = { subtree: true, childList: true };
+					this.__mutationObserver.observe(this.__getContentContainer(), config);
+				}
 			}.bind(this));
 		},
 
@@ -263,7 +263,9 @@
 			this.unlisten(this, 'd2l-dropdown-close', '__onClose');
 			this.unlisten(this, 'd2l-dropdown-position', '__toggleScrollStyles');
 			this.unlisten(this.__content, 'scroll', '__toggleScrollStyles');
-			this.__mutationObserver.disconnect();
+			if (!this.noAutoFit) {
+				this.__mutationObserver.disconnect();
+			}
 		},
 
 		close: function() {
@@ -554,7 +556,15 @@
 		},
 
 		__toggleOverflowY: function() {
+			if (!this.__content || !this.__content.style || !this.__content.style.maxHeight){
+				return;
+			}
+
 			var maxHeight = parseInt(this.__content.style.maxHeight.replace(/[^0-9\.]/g, ''), 10);
+			if (!maxHeight){
+				return;
+			}
+
 			if (this.__content.scrollHeight > maxHeight) {
 				this.__content.style.overflowY = 'auto';
 			} else {

--- a/d2l-dropdown-content-behavior.html
+++ b/d2l-dropdown-content-behavior.html
@@ -224,10 +224,6 @@
 			this.__onResize = this.__onResize.bind(this);
 			this.__onAutoCloseFocus = this.__onAutoCloseFocus.bind(this);
 			this.__onAutoCloseClick = this.__onAutoCloseClick.bind(this);
-
-			this.__mutationObserver = new MutationObserver(function() {
-				this.__toggleOverflowY();
-			}.bind(this));
 		},
 
 		attached: function() {
@@ -247,11 +243,6 @@
 				this.listen(this, 'd2l-dropdown-close', '__onClose');
 				this.listen(this, 'd2l-dropdown-position', '__toggleScrollStyles');
 				this.listen(this.__content, 'scroll', '__toggleScrollStyles');
-
-				if (!this.noAutoFit) {
-					var config = { subtree: true, childList: true };
-					this.__mutationObserver.observe(this.__getContentContainer(), config);
-				}
 			}.bind(this));
 		},
 
@@ -263,9 +254,6 @@
 			this.unlisten(this, 'd2l-dropdown-close', '__onClose');
 			this.unlisten(this, 'd2l-dropdown-position', '__toggleScrollStyles');
 			this.unlisten(this.__content, 'scroll', '__toggleScrollStyles');
-			if (!this.noAutoFit) {
-				this.__mutationObserver.disconnect();
-			}
 		},
 
 		close: function() {
@@ -435,9 +423,23 @@
 
 				doOpen();
 
+				if (!this.noAutoFit) {
+					if (!this.__mutationObserver) {
+						this.__mutationObserver = new MutationObserver(function() {
+							this.__toggleOverflowY();
+						}.bind(this));
+					}
+					var config = { subtree: true, childList: true };
+					this.__mutationObserver.observe(this.__getContentContainer(), config);
+				}
+
 			} else {
 
 				this.fire('d2l-dropdown-close');
+
+				if (!this.noAutoFit && this.__mutationObserver) {
+					this.__mutationObserver.disconnect();
+				}
 
 			}
 
@@ -560,7 +562,7 @@
 				return;
 			}
 
-			var maxHeight = parseInt(this.__content.style.maxHeight.replace(/[^0-9\.]/g, ''), 10);
+			var maxHeight = parseInt(this.__content.style.maxHeight, 10);
 			if (!maxHeight) {
 				return;
 			}

--- a/d2l-dropdown-content-behavior.html
+++ b/d2l-dropdown-content-behavior.html
@@ -158,8 +158,6 @@
 (function() {
 	'use strict';
 
-	var mutationObserver;
-
 	/** @polymerBehavior */
 	var DropdownContentBehavior = {
 
@@ -220,12 +218,14 @@
 
 		__previousFocusableAncestor: null,
 
+		__mutationObserver: null,
+
 		ready: function() {
 			this.__onResize = this.__onResize.bind(this);
 			this.__onAutoCloseFocus = this.__onAutoCloseFocus.bind(this);
 			this.__onAutoCloseClick = this.__onAutoCloseClick.bind(this);
 
-			mutationObserver = new MutationObserver(function(mutations) {
+			this.__mutationObserver = new MutationObserver(function(mutations) {
 				mutations.forEach(function(mutation) {
 					this.__toggleOverflowY();
 				}.bind(this));
@@ -250,8 +250,8 @@
 				this.listen(this, 'd2l-dropdown-position', '__toggleScrollStyles');
 				this.listen(this.__content, 'scroll', '__toggleScrollStyles');
 
-				var config = { childList: true }
-				mutationObserver.observe(this.__getContentContainer(), config);
+				var config = { subtree: true, childList: true }
+				this.__mutationObserver.observe(this.__getContentContainer(), config);
 			}.bind(this));
 		},
 
@@ -263,7 +263,7 @@
 			this.unlisten(this, 'd2l-dropdown-close', '__onClose');
 			this.unlisten(this, 'd2l-dropdown-position', '__toggleScrollStyles');
 			this.unlisten(this.__content, 'scroll', '__toggleScrollStyles');
-			mutationObserver.disconnect();
+			this.__mutationObserver.disconnect();
 		},
 
 		close: function() {
@@ -554,13 +554,12 @@
 		},
 
 		__toggleOverflowY: function() {
-			var content = this.__getContentContainer();
-			var maxHeight = parseInt(content.style.maxHeight.replace(/[^0-9\.]/g, ''), 10);
-			if (content.scrollHeight > maxHeight) {
-				content.style.overflowY = 'auto';
+			var maxHeight = parseInt(this.__content.style.maxHeight.replace(/[^0-9\.]/g, ''), 10);
+			if (this.__content.scrollHeight > maxHeight) {
+				this.__content.style.overflowY = 'auto';
 			} else {
 				/* needed for IE */
-				content.style.overflowY = '';
+				this.__content.style.overflowY = '';
 			}
 		},
 


### PR DESCRIPTION
In earlier implementation, content.style.overflowY = 'auto' will not be triggered until we resize the window. However, when user clicks "Load More" button, the event won't be fired which caused no scrollbar introduced.