### PR TITLE
Update color of primary opener icon.

### DIFF
--- a/d2l-dropdown-button.html
+++ b/d2l-dropdown-button.html
@@ -14,6 +14,9 @@
 			:host button > span {
 				margin-right: 0.6rem;
 			}
+			:host([primary]) d2l-icon {
+				color: white;
+			}
 			:host-context([dir="rtl"]) button > span {
 				margin-left: 0.6rem;
 				margin-right: 0;


### PR DESCRIPTION
This necessary to override the explicit ferrite color defined at part of `d2l-icon` styles.  Otherwise, the primary button menu opener has a ferrite icon on blue button.