### PR TITLE
Remove d2l-polymer-behaviors variant since it should not be needed fo…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,6 @@
         "d2l-icons": "^3.6.0",
         "d2l-menu": "^0.3.7",
         "d2l-offscreen": "^2.2.5",
-        "d2l-polymer-behaviors": "^0.0.5",
         "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0",
         "polymer": "Polymer/polymer#^1.9.1"
       },


### PR DESCRIPTION
…r hybrid, and results in bower conflicts.