### PR TITLE
Dbatiste/fix auto close focus for shadow dom

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "package.json"
   ],
   "dependencies": {
-    "d2l-button": "^4.0.0",
+    "d2l-button": "^4.0.1",
     "d2l-colors": "^2.4.0 || ^3.1.0",
     "d2l-icons": "^3.6.0 || ^4.4.0",
     "d2l-menu": "^0.3.7 || ^1.0.3",

--- a/d2l-dropdown-content-behavior.html
+++ b/d2l-dropdown-content-behavior.html
@@ -387,6 +387,7 @@
 				return;
 			}
 			var activeElement = Polymer.dom(document.activeElement).node;
+			activeElement = this.root.activeElement || activeElement;
 			if (!D2L.Dom.isComposedAncestor(this, activeElement)) {
 				return;
 			}

--- a/d2l-dropdown-content-behavior.html
+++ b/d2l-dropdown-content-behavior.html
@@ -355,6 +355,8 @@
 				}
 
 				var activeElement = Polymer.dom(document.activeElement).node;
+				activeElement = this.root.activeElement || activeElement;
+
 				if (D2L.Dom.isComposedAncestor(this, activeElement)
 					|| D2L.Dom.isComposedAncestor(this.__getOpener(), activeElement)) {
 					return;


### PR DESCRIPTION
Fixes:

* update to latest version of d2l-button so that focus can be properly applied to button opener
* update to properly resolve activeElement when a) focus is lost; and b) when closing the dropdown, when shadow-dom is enabled.