### PR TITLE
Fix auto-close for when shadow-dom is enabled.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "d2l-icons": "^4.5.1",
     "d2l-menu": "^1.0.4",
     "d2l-offscreen": "^3.0.3",
-    "d2l-polymer-behaviors": "^1.1.1",
+    "d2l-polymer-behaviors": "^1.2.0",
     "iron-iconset-svg": "^2.1.0",
     "polymer": "1.9.1 - 2"
   },

--- a/d2l-dropdown-content-behavior.html
+++ b/d2l-dropdown-content-behavior.html
@@ -445,8 +445,7 @@
 					return;
 				}
 
-				var activeElement = Polymer.dom(document.activeElement).node;
-				activeElement = this.root.activeElement || activeElement;
+				var activeElement = D2L.Dom.Focus.getComposedActiveElement();
 
 				if (D2L.Dom.isComposedAncestor(this, activeElement)
 					|| D2L.Dom.isComposedAncestor(this.__getOpener(), activeElement)) {
@@ -474,16 +473,20 @@
 		},
 
 		__onClose: function(e) {
+
 			if (e.target !== this || !document.activeElement) {
 				return;
 			}
-			var activeElement = Polymer.dom(document.activeElement).node;
-			activeElement = this.root.activeElement || activeElement;
+
+			var activeElement = D2L.Dom.Focus.getComposedActiveElement();
+
 			if (!D2L.Dom.isComposedAncestor(this, activeElement)) {
 				return;
 			}
+
 			var opener = this.__getOpener();
 			opener.getOpenerElement().focus();
+
 		},
 
 		__onKeyUp: function(e) {


### PR DESCRIPTION
Fix for when shadow-dom is enabled and dropdown is in shadow-dom of another component.  Without this, dropdown closes when users click on items inside dropdown before the click is triggers on the target, resulting in it being impossible to activate items inside the dropdown with mouse.