### PR TITLE
use d2l-button-icon in d2l-dropdown-context-menu

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "wct.conf.json"
   ],
   "dependencies": {
-    "d2l-button": "^4.5.0",
+    "d2l-button": "^4.6.0",
     "d2l-colors": "^3.1.2",
     "d2l-icons": "^5.0.0",
     "d2l-menu": "^1.1.0",

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,6 @@
     "d2l-colors": "^3.1.2",
     "d2l-icons": "^5.0.0",
     "d2l-menu": "^1.1.0",
-    "d2l-offscreen": "^3.0.3",
     "d2l-polymer-behaviors": "^1.2.0",
     "iron-iconset-svg": "^2.1.0",
     "polymer": "1 - 2"

--- a/d2l-dropdown-context-menu.html
+++ b/d2l-dropdown-context-menu.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-button/d2l-button-icon.html">
+<link rel="import" href="../d2l-icons/tier1-icons.html">
 <link rel="import" href="d2l-dropdown-opener-behavior.html">
 
 <!--
@@ -11,7 +12,7 @@ Polymer-based web component for dropdown using a context-menu opener.
 
 <dom-module id="d2l-dropdown-context-menu">
 	<template>
-		<style include="d2l-dropdown-opener-styles d2l-offscreen-shared-styles">
+		<style include="d2l-dropdown-opener-styles">
 			:host {
 				display: inline-block;
 			}

--- a/d2l-dropdown-context-menu.html
+++ b/d2l-dropdown-context-menu.html
@@ -1,8 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../d2l-colors/d2l-colors.html">
-<link rel="import" href="../d2l-icons/d2l-icon.html">
-<link rel="import" href="../d2l-icons/tier1-icons.html">
-<link rel="import" href="../d2l-offscreen/d2l-offscreen-shared-styles.html">
+<link rel="import" href="../d2l-button/d2l-button-icon.html">
 <link rel="import" href="d2l-dropdown-opener-behavior.html">
 
 <!--
@@ -18,50 +15,17 @@ Polymer-based web component for dropdown using a context-menu opener.
 			:host {
 				display: inline-block;
 			}
-			:host button {
-				background-color: transparent;
-				border: 1px solid transparent;
-				border-radius: 0.3rem;
-				box-sizing: border-box;
-				cursor: pointer;
-				height: calc(1.4rem + 2px);
-				outline-style: none;
-				width: calc(1.4rem + 2px);
-			}
-			:host button:focus,
-			:host button:hover {
-				border-color: var(--d2l-color-corundum);
-				color: var(--d2l-color-celestine-minus-1);
-			}
-			:host button:focus d2l-icon,
-			:host button:hover d2l-icon {
-				color: var(--d2l-color-celestine-minus-1);
-			}
-			:host([opened]) button {
-				border-color: var(--d2l-color-corundum);
-				color: var(--d2l-color-celestine);
-			}
-			:host([opened]) button d2l-icon {
-				color: var(--d2l-color-celestine);
-			}
-			:host button > div {
-				@apply --d2l-offscreen;
-			}
-			:host(:dir(rtl)) button > div {
-				@apply --d2l-offscreen-rtl;
-			}
-			:host-context([dir="rtl"]) button > div {
-				@apply --d2l-offscreen-rtl;
-			}
-			:host d2l-icon {
-				height: 0.8rem;
-				width: 0.8rem;
+			:host d2l-button-icon {
+				--d2l-button-icon-min-height: calc(1.6rem + 2px);
+				--d2l-button-icon-min-width: calc(1.6rem + 2px);
 			}
 		</style>
-		<button>
-			<div>[[text]]</div>
-			<d2l-icon icon="d2l-tier1:chevron-down"></d2l-icon>
-		</button>
+		<d2l-button-icon
+			aria-label$="[[text]]"
+			disabled=[[disabled]]
+			icon="d2l-tier1:chevron-down"
+			text="[[text]]">
+		</d2l-button-icon>
 		<slot></slot>
 	</template>
 	<script>
@@ -91,15 +55,17 @@ Polymer-based web component for dropdown using a context-menu opener.
 			 * @return {HTMLElement}
 			 */
 			getOpenerElement: function() {
-				return this.$$('button');
+				return this.$$('d2l-button-icon');
 			},
 
 			_onClose: function() {
 				this.removeAttribute('opened');
+				this.$$('d2l-button-icon').removeAttribute('active');
 			},
 
 			_onOpen: function() {
 				this.setAttribute('opened', '');
+				this.$$('d2l-button-icon').setAttribute('active', 'true');
 			}
 
 		});

--- a/d2l-dropdown-opener-behavior.html
+++ b/d2l-dropdown-opener-behavior.html
@@ -42,6 +42,14 @@
 			noAutoOpen: {
 				type: Boolean,
 				reflectToAttribute: true
+			},
+
+			/**
+			 * Standard HTML disabled.
+			 */
+			disabled: {
+				type: Boolean,
+				reflectToAttribute: true
 			}
 
 		},
@@ -105,7 +113,7 @@
 		 */
 		toggleOpen: function(applyFocus) {
 			var content = this.queryEffectiveChildren('[d2l-dropdown-content]');
-			if (!content) {
+			if (!content || this.disabled) {
 				return;
 			}
 			content.toggleOpen(applyFocus);

--- a/d2l-dropdown-opener-behavior.html
+++ b/d2l-dropdown-opener-behavior.html
@@ -112,8 +112,12 @@
 		 * @param {Boolean} applyFocus Whether focus should be automatically move to first focusable upon opening.
 		 */
 		toggleOpen: function(applyFocus) {
+			if (this.disabled) {
+				return;
+			}
+
 			var content = this.queryEffectiveChildren('[d2l-dropdown-content]');
-			if (!content || this.disabled) {
+			if (!content) {
 				return;
 			}
 			content.toggleOpen(applyFocus);


### PR DESCRIPTION
button PR related to `active` coming shortly
The `active` attribute is so that when the menu is open, the button doesn't go back to the default state (e.g., shows hover behaviour)