### PR TITLE
Dbatiste/translucent openers

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ dropdown.addEventListener('click', function() {
 
 #### Context Menu Opener
 
-`d2l-dropdown-context-menu` is a simple/minimal opener for dropdown content (`d2l-dropdown-content` or `d2l-dropdown-menu`).  Provide `text` for accessibility and content component as needed.
+`d2l-dropdown-context-menu` is a simple/minimal opener for dropdown content (`d2l-dropdown-content` or `d2l-dropdown-menu`).  Provide `text` for accessibility and content component as needed.  Optionally, specify the `translucent` attribute for busy/rich backgrounds.
 
 <!---
 ```
@@ -236,7 +236,7 @@ dropdown.addEventListener('click', function() {
 
 #### More Opener
 
-`d2l-dropdown-more` is a simple opener using `d2l-tier1:more` as the button's icon.
+`d2l-dropdown-more` is a simple/minimal opener for dropdown content (`d2l-dropdown-content` or `d2l-dropdown-menu`).  Provide `text` for accessibility and content component as needed.  Optionally, specify the `translucent` attribute for busy/rich backgrounds.
 
 <!---
 ```

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "wct.conf.json"
   ],
   "dependencies": {
-    "d2l-button": "^4.6.0",
+    "d2l-button": "^4.7.1",
     "d2l-colors": "^3.1.2",
     "d2l-icons": "^5.0.0",
     "d2l-menu": "^1.1.0",

--- a/d2l-dropdown-context-menu.html
+++ b/d2l-dropdown-context-menu.html
@@ -25,7 +25,8 @@ Polymer-based web component for dropdown using a context-menu opener.
 			aria-label$="[[text]]"
 			disabled=[[disabled]]
 			icon="d2l-tier1:chevron-down"
-			text="[[text]]">
+			text="[[text]]"
+			translucent=[[translucent]]>
 		</d2l-button-icon>
 		<slot></slot>
 	</template>
@@ -42,7 +43,14 @@ Polymer-based web component for dropdown using a context-menu opener.
 				/**
 				 * Label for the context-menu button (required for accessibility).
 				 */
-				text: String
+				text: String,
+
+				/**
+				 * Whether the opener is translucent.
+				 */
+				translucent: {
+					type: Boolean
+				}
 
 			},
 

--- a/d2l-dropdown-more.html
+++ b/d2l-dropdown-more.html
@@ -1,12 +1,11 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../d2l-colors/d2l-colors.html">
-<link rel="import" href="../d2l-icons/d2l-icon.html">
+<link rel="import" href="../d2l-button/d2l-button-icon.html">
 <link rel="import" href="../d2l-icons/tier1-icons.html">
 <link rel="import" href="d2l-dropdown-opener-behavior.html">
 
 <!--
 `d2l-dropdown-more`
-Polymer-based web component for dropdown using a "more" opener.
+Polymer-based web component for dropdown using a more [...] opener.
 
 @demo demo/dropdown-more.html More Opener
 -->
@@ -14,34 +13,21 @@ Polymer-based web component for dropdown using a "more" opener.
 <dom-module id="d2l-dropdown-more">
 	<template>
 		<style include="d2l-dropdown-opener-styles">
-			:host .d2l-dropdown-more-container {
-				display: flex;
+			:host {
+				display: inline-block;
 			}
-			:host button {
-				border: none;
-				border-radius: 5px;
-				background: rgba(0,0,0,0.5);
-				color: white;
-				cursor: pointer;
-				height: 35px;
-				width: 35px;
-				transition: background 0.5s;
-			}
-			:host button:hover, :host button:focus, :host button[active] {
-				background: var(--d2l-color-celestine);
-				outline: 0;
-			}
-			:host d2l-icon {
-				color: white;
-				--d2l-icon-width: 18px;
-				--d2l-icon-height: 18px;
+			:host d2l-button-icon {
+				--d2l-button-icon-min-height: calc(1.6rem + 2px);
+				--d2l-button-icon-min-width: calc(1.6rem + 2px);
 			}
 		</style>
-		<div class="d2l-dropdown-more-container">
-			<button aria-label$="[[label]]">
-				<d2l-icon icon="d2l-tier1:more"></d2l-icon>
-			</button>
-		</div>
+		<d2l-button-icon
+			aria-label$="[[text]]"
+			disabled=[[disabled]]
+			icon="d2l-tier1:more"
+			text="[[text]]"
+			translucent=[[translucent]]>
+		</d2l-button-icon>
 		<slot></slot>
 	</template>
 	<script>
@@ -53,10 +39,24 @@ Polymer-based web component for dropdown using a "more" opener.
 			],
 
 			properties: {
+
 				/**
-				 * Label for the "more" button (required for accessibility).
+				 * Label for the context-menu button (required for accessibility).
 				 */
-				label: String
+				text: String,
+
+				/**
+				 * Whether the opener is translucent.
+				 */
+				translucent: {
+					type: Boolean
+				}
+
+			},
+
+			listeners: {
+				'd2l-dropdown-close': '_onClose',
+				'd2l-dropdown-open': '_onOpen'
 			},
 
 			/**
@@ -64,7 +64,15 @@ Polymer-based web component for dropdown using a "more" opener.
 			 * @return {HTMLElement}
 			 */
 			getOpenerElement: function() {
-				return this.$$('button');
+				return this.$$('d2l-button-icon');
+			},
+
+			_onClose: function() {
+				this.removeAttribute('opened');
+			},
+
+			_onOpen: function() {
+				this.setAttribute('opened', '');
 			}
 
 		});

--- a/demo/dropdown-context-menu.html
+++ b/demo/dropdown-context-menu.html
@@ -37,6 +37,18 @@
 				</template>
 			</demo-snippet>
 
+			<h3>Dropdown Context-Menu Opener (Translucent)</h3>
+			<demo-snippet>
+				<template>
+					<d2l-dropdown-context-menu text="Open!" translucent>
+						<d2l-dropdown-content max-width="400">
+							<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+							<a href="http://www.desire2learn.com">D2L</a>
+						</d2l-dropdown-content>
+					</d2l-dropdown-context-menu>
+				</template>
+			</demo-snippet>
+
 		</div>
 		<script>
 			document.body.addEventListener('d2l-dropdown-open', function(e) {

--- a/demo/dropdown-more.html
+++ b/demo/dropdown-more.html
@@ -49,6 +49,29 @@
 				</template>
 			</demo-snippet>
 
+			<h3>Dropdown More Button Opener (Translucent)</h3>
+			<demo-snippet>
+				<template>
+					<d2l-dropdown-more label="Open!" translucent>
+						<d2l-dropdown-menu>
+							<d2l-menu label="Astronomy">
+								<d2l-menu-item text="Introduction"></d2l-menu-item>
+								<d2l-menu-item text="Searching for the Heavens "></d2l-menu-item>
+								<d2l-menu-item text="The Night Sky">
+									<d2l-menu>
+										<d2l-menu-item text="Constellations"></d2l-menu-item>
+										<d2l-menu-item text="Mapping the Heavens"></d2l-menu-item>
+										<d2l-menu-item text="Reading Star Maps"></d2l-menu-item>
+										<d2l-menu-item text="Telescopes"></d2l-menu-item>
+									</d2l-menu>
+								</d2l-menu-item>
+								<d2l-menu-item text="The Universe"></d2l-menu-item>
+							</d2l-menu>
+						</d2l-dropdown-menu>
+					</d2l-dropdown-more>
+				</template>
+			</demo-snippet>
+
 		</div>
 		<script>
 			document.body.addEventListener('d2l-dropdown-open', function(e) {

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -24,7 +24,7 @@
         },
         {
           "browserName": "safari",
-          "platform": "OS X 10.12",
+          "platform": "OS X 10.13",
           "version": ""
         },
         {


### PR DESCRIPTION
For now, the `context-menu` and `more` openers are separate components, but they are now consistent, there icon being the difference.

I will add the `translucent` attribute to existing instances of `more` before releasing a new version of this component.  A couple more changes to come (visible-on-ancestor behavior, and normalizing size to 42px) - will do separate PRs for those changes.