### PR TITLE
Use consistent sizing for dropdown openers.

### DIFF
--- a/d2l-dropdown-context-menu.html
+++ b/d2l-dropdown-context-menu.html
@@ -17,10 +17,6 @@ Polymer-based web component for dropdown using a context-menu opener.
 			:host {
 				display: inline-block;
 			}
-			:host d2l-button-icon {
-				--d2l-button-icon-min-height: calc(1.6rem + 2px);
-				--d2l-button-icon-min-width: calc(1.6rem + 2px);
-			}
 		</style>
 		<d2l-button-icon
 			aria-label$="[[text]]"

--- a/d2l-dropdown-more.html
+++ b/d2l-dropdown-more.html
@@ -17,10 +17,6 @@ Polymer-based web component for dropdown using a more [...] opener.
 			:host {
 				display: inline-block;
 			}
-			:host d2l-button-icon {
-				--d2l-button-icon-min-height: calc(1.6rem + 2px);
-				--d2l-button-icon-min-width: calc(1.6rem + 2px);
-			}
 		</style>
 		<d2l-button-icon
 			aria-label$="[[text]]"


### PR DESCRIPTION
This results in consistent sizing for openers and buttons (42x42px).