### PR TITLE
Use menu size details if reported.

### DIFF
--- a/d2l-dropdown-content-behavior.js
+++ b/d2l-dropdown-content-behavior.js
@@ -571,7 +571,7 @@ D2L.PolymerBehaviors.DropdownContentBehavior = {
 
 	},
 
-	__position: function(ignoreVertical) {
+	__position: function(ignoreVertical, contentSize) {
 
 		var opener = this.__getOpener();
 		if (!opener) {
@@ -593,7 +593,7 @@ D2L.PolymerBehaviors.DropdownContentBehavior = {
 		var adjustPosition = function() {
 
 			var targetRect = target.getBoundingClientRect();
-			var contentRect = content.getBoundingClientRect();
+			var contentRect = contentSize ? contentSize : content.getBoundingClientRect();
 
 			var spaceAround = {
 				above: targetRect.top - 50,

--- a/d2l-dropdown-menu.js
+++ b/d2l-dropdown-menu.js
@@ -77,8 +77,8 @@ Polymer({
 
 	},
 
-	_onMenuResize: function() {
-		this.__position(!this._initializingHeight);
+	_onMenuResize: function(e) {
+		this.__position(!this._initializingHeight, e.details);
 		this._initializingHeight = false;
 	},
 

--- a/d2l-dropdown-menu.js
+++ b/d2l-dropdown-menu.js
@@ -78,7 +78,7 @@ Polymer({
 	},
 
 	_onMenuResize: function(e) {
-		this.__position(!this._initializingHeight, e.details);
+		this.__position(!this._initializingHeight, e.detail);
 		this._initializingHeight = false;
 	},
 


### PR DESCRIPTION
It may be useful to get the actual numbers from the event, instead of calculating the content size.
Problem: sometimes the bound rectangle returns `height: 1`, because the menu didn't have time to render, the menu height is actually reports the proper height. This causes the menu to be rendered at the bottom when there is no space.
On the second time when use pressed the dropdown opener button - it always shows up correctly because the menu has been rendered. 

Note: This is how I solved the issue in the React 16 using Polymer 3 components. It may not be the case if we use Polymer App.