### PR TITLE
Fix to apply focus on open so that IE/Edge don't crazily invoke click

### DIFF
--- a/d2l-dropdown-content-behavior.js
+++ b/d2l-dropdown-content-behavior.js
@@ -530,7 +530,10 @@ D2L.PolymerBehaviors.DropdownContentBehavior = {
 			if (!this.noAutoFocus && this.__applyFocus) {
 				var focusable = D2L.Dom.Focus.getFirstFocusableDescendant(this);
 				if (focusable) {
-					focusable.focus();
+					// bumping this to the next frame is required to prevent IE/Edge from crazily invoking click on the focused element
+					requestAnimationFrame(function() {
+						focusable.focus();
+					});
 				} else {
 					content.setAttribute('tabindex', '-1');
 					content.focus();

--- a/test/dropdown-content.html
+++ b/test/dropdown-content.html
@@ -163,8 +163,10 @@ describe('<d2l-dropdown-content>', function() {
 
 		it('focuses on descendant when opened', function(done) {
 			content.addEventListener('d2l-dropdown-open', function() {
-				expect(document.activeElement).to.equal(content.querySelector('#focusable_inside'));
-				done();
+				requestAnimationFrame(function() {
+					expect(document.activeElement).to.equal(content.querySelector('#focusable_inside'));
+					done();
+				});
 			});
 			content.setAttribute('opened', true);
 		});
@@ -172,8 +174,10 @@ describe('<d2l-dropdown-content>', function() {
 		it('does not focus on descendant when opened and no-auto-focus attribute is specified', function(done) {
 			var activeElement = document.activeElement;
 			content.addEventListener('d2l-dropdown-open', function() {
-				expect(document.activeElement).to.equal(activeElement);
-				done();
+				requestAnimationFrame(function() {
+					expect(document.activeElement).to.equal(activeElement);
+					done();
+				});
 			});
 			content.setAttribute('no-auto-focus', true);
 			content.setAttribute('opened', true);


### PR DESCRIPTION
Default dropdown behavior is to focus on the first focusable element upon opening the dropdown with the keyboard.  In IE/Edge however, the `focus()` call needs to be bumped to the next frame, possibly because the dropdown may not be made visible yet.  This seems to be a crazy bug with IE/Edge that it ends up triggering the click event on the focused element.  To side-step this, we can bump `focus()` of the first focusable element to the next frame.