### PR TITLE
removing unneeded dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "d2l-colors": "BrightspaceUI/colors#semver:^4",
     "d2l-icons": "BrightspaceUI/icons#semver:^6",
     "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
-    "@polymer/iron-iconset-svg": "^3.0.0",
     "@polymer/polymer": "^3.0.0"
   }
 }


### PR DESCRIPTION
We want to stop using `iron-iconset-svg` when we move to Core/icons. This is seemingly not needed or referenced anywhere in dropdown.