### PR TITLE
Proposal Removing annoying line-height

### DIFF
--- a/d2l-dropdown-content-behavior.js
+++ b/d2l-dropdown-content-behavior.js
@@ -85,6 +85,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-dropdown-content-styles">
 				border-radius: 0.3rem;
 				box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.15);
 				box-sizing: border-box;
+				line-height: 0;
 				min-width: 70px;
 				max-width: 370px;
 				position: absolute;


### PR DESCRIPTION
There is a line-height that is applied to `.d2l-dropdown-content-width` from d2l-typography. I see a couple of problems.
1. d2l-typography is being applied to non-text elements. 
2. line-height affecting the height when it's not supposed to
3. d2l-menu-item hard-codes their own line-height, sending line-height to its children is useless, since the only child will always be a d2l-menu-item.

So essentially I see 2 solutions:
1. set one line-height in the parent, and kill all css mentions of line height in the children (not-recommended but I assume that d2l-menu is used in other places).
2. Let the children decide their own line-height, kill all other mentions everywhere else.

I don't understand the logic of how css is supposed to work in this case. I would assume that applying the line-height to a parent would then apply the line-height to the child. That's what I expect. What actually happens is that not only does the line-height of the parent affect the child, it then dictates the child, it then changes its height based on it, even if the child might have overridden it's own line-height.

To explain this with an (albeit comical) example, its like how in real life you put a printed piece of paper on a table. You might want a specific line-height to dictate the spacing of the text in the paper, that makes sense. but what you don't want is some line-height of the table to affect the space between the edge of the table and the paper. That wouldn't make sense.