### PR TITLE
Allow use of @brightspace-ui/core/components/menu

### DIFF
--- a/d2l-dropdown-menu.js
+++ b/d2l-dropdown-menu.js
@@ -11,7 +11,6 @@ Polymer-based web component for dropdown menu content.
 */
 import '@polymer/polymer/polymer-legacy.js';
 
-import 'd2l-menu/d2l-menu.js';
 import './d2l-dropdown-content-behavior.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
@@ -41,7 +40,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-dropdown-menu">
 			<div></div>
 		</div>
 	</template>
-	
+
 </dom-module>`;
 
 document.head.appendChild($_documentContainer.content);

--- a/demo/dropdown-menu.html
+++ b/demo/dropdown-menu.html
@@ -7,7 +7,8 @@
 		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
-		<script type="module" src="../../d2l-menu/d2l-menu.js"></script>
+		<script type="module" src="../../@brightspace-ui/core/components/menu/menu.js"></script>
+		<script type="module" src="../../@brightspace-ui/core/components/menu/menu-item.js"></script>
 		<script type="module" src="../d2l-dropdown.js"></script>
 		<script type="module" src="../d2l-dropdown-menu.js"></script>
 		<!-- FIXME(polymer-modulizer):
@@ -130,7 +131,8 @@ document.body.appendChild($_documentContainer.content);
 import '@polymer/iron-demo-helpers/demo-pages-shared-styles.js';
 import '@polymer/iron-demo-helpers/demo-snippet.js';
 import '@brightspace-ui/core/components/typography/typography.js';
-import 'd2l-menu/d2l-menu.js';
+import '@brightspace-ui/core/components/menu/menu.js';
+import '@brightspace-ui/core/components/menu/menu-item.js';
 import '../d2l-dropdown.js';
 import '../d2l-dropdown-menu.js';
 document.body.addEventListener('d2l-dropdown-open', function(e) {

--- a/demo/dropdown-more.html
+++ b/demo/dropdown-more.html
@@ -7,7 +7,8 @@
 		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
-		<script type="module" src="../../d2l-menu/d2l-menu.js"></script>
+		<script type="module" src="../../@brightspace-ui/core/components/menu/menu.js"></script>
+		<script type="module" src="../../@brightspace-ui/core/components/menu/menu-item.js"></script>
 		<script type="module" src="../d2l-dropdown-more.js"></script>
 		<script type="module" src="../d2l-dropdown-menu.js"></script>
 		<link rel="stylesheet" type="text/css" href="demo-styles.css">
@@ -144,7 +145,8 @@ document.body.appendChild($_documentContainer.content);
 import '@polymer/iron-demo-helpers/demo-pages-shared-styles.js';
 import '@polymer/iron-demo-helpers/demo-snippet.js';
 import '@brightspace-ui/core/components/typography/typography.js';
-import 'd2l-menu/d2l-menu.js';
+import '@brightspace-ui/core/components/menu/menu.js';
+import '@brightspace-ui/core/components/menu/menu-item.js';
 import '../d2l-dropdown-more.js';
 import '../d2l-dropdown-menu.js';
 document.body.addEventListener('d2l-dropdown-open', function(e) {

--- a/demo/dropdown-tabs-menu-component.js
+++ b/demo/dropdown-tabs-menu-component.js
@@ -1,6 +1,7 @@
 import '@polymer/polymer/polymer-legacy.js';
 import 'd2l-tabs/d2l-tabs.js';
-import 'd2l-menu/d2l-menu.js';
+import '@brightspace-ui/core/components/menu/menu.js';
+import '@brightspace-ui/core/components/menu/menu-item.js';
 import '../d2l-dropdown.js';
 import '../d2l-dropdown-tabs.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';

--- a/demo/dropdown-tabs-menu.html
+++ b/demo/dropdown-tabs-menu.html
@@ -7,7 +7,8 @@
 		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
-		<script type="module" src="../../d2l-menu/d2l-menu.js"></script>
+		<script type="module" src="../../@brightspace-ui/core/components/menu/menu.js"></script>
+		<script type="module" src="../../@brightspace-ui/core/components/menu/menu-item.js"></script>
 		<script type="module" src="../d2l-dropdown.js"></script>
 		<script type="module" src="../d2l-dropdown-menu.js"></script>
 		<script type="module" src="./dropdown-tabs-menu-component.js"></script>
@@ -61,7 +62,8 @@ document.body.appendChild($_documentContainer.content);
 import '@polymer/iron-demo-helpers/demo-pages-shared-styles.js';
 import '@polymer/iron-demo-helpers/demo-snippet.js';
 import '@brightspace-ui/core/components/typography/typography.js';
-import 'd2l-menu/d2l-menu.js';
+import '@brightspace-ui/core/components/menu/menu.js';
+import '@brightspace-ui/core/components/menu/menu-item.js';
 import '../d2l-dropdown.js';
 import '../d2l-dropdown-menu.js';
 document.body.addEventListener('d2l-dropdown-open', function(e) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@polymer/iron-test-helpers": "^3.0.0",
     "@webcomponents/webcomponentsjs": "^2.2.7",
     "babel-eslint": "^10.0.1",
-    "d2l-menu": "BrightspaceUI/menu#semver:^2",
     "d2l-tabs": "BrightspaceUI/tabs#semver:^1",
     "eslint": "^4.15.0",
     "eslint-config-brightspace": "^0.4.0",


### PR DESCRIPTION
Before this change, when trying to use dropdown-menu with `@brightspace-ui/core/components/menu`, either d2l-menu was not found, or the duplicate d2l-menu registration fails.