### PR TITLE
Lit Compatibility

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "brightspace/polymer-3-config"
+  "extends": "brightspace/polymer-3-config",
+  "globals": {
+    "Promise": false
+  }
 }

--- a/d2l-dropdown-content-behavior.js
+++ b/d2l-dropdown-content-behavior.js
@@ -370,6 +370,7 @@ D2L.PolymerBehaviors.DropdownContentBehavior = {
 		}
 		var domIf = this.$$('dom-if') || this.$$('template');
 		domIf.render();
+		return Promise.resolve();
 	},
 
 	/**

--- a/d2l-dropdown-opener-behavior.js
+++ b/d2l-dropdown-opener-behavior.js
@@ -117,11 +117,15 @@ D2L.PolymerBehaviors.DropdownOpenerBehavior = {
 			return;
 		}
 
-		var content = this.queryEffectiveChildren('[d2l-dropdown-content]');
+		var content = this.__getContentElement();
 		if (!content) {
 			return;
 		}
 		content.toggleOpen(applyFocus);
+	},
+
+	__getContentElement: function() {
+		return this.queryEffectiveChildren('[d2l-dropdown-content]');
 	},
 
 	__onKeyPress: function(e) {


### PR DESCRIPTION
Update the Polymer 3 dropdown to have a compatible interface with the lit dropdown so that breaking changes can be fixed before switching over to the lit version.

1. [`forceRender` is now `async` in the lit version of the Dropdown.](https://github.com/BrightspaceUI/core/blob/master/components/dropdown/dropdown-content-mixin.js#L186) This will allow anywhere `forceRender` is called to be updated to use promises.
2. [My Courses accesses the internal dropdown content using `queryEffectiveChildren` which doesn't exist in lit.](https://github.com/Brightspace/d2l-my-courses-ui/blob/master/src/d2l-all-courses.js#L693) I will be updating this to instead call [`__getContentElement` which has been updated to get the slot's `assignedNodes`.](https://github.com/BrightspaceUI/core/blob/master/components/dropdown/dropdown-opener-mixin.js#L92)